### PR TITLE
Add necessary files and changes for including the hyena dataset

### DIFF
--- a/configs/hyenas/animal2vec_base_pretrain_10s-2-1_5_sinc_38ms_mixup_pswish.yaml
+++ b/configs/hyenas/animal2vec_base_pretrain_10s-2-1_5_sinc_38ms_mixup_pswish.yaml
@@ -1,0 +1,144 @@
+# @package _group_
+
+common:
+  fp16: true
+  log_format: json
+  log_interval: 1418  # log every tenth of an epoch
+  tensorboard_logdir: tb
+  min_loss_scale: 1e-6
+  fp16_no_flatten_grads: true
+  fp16_init_scale: 1
+
+checkpoint:
+  save_interval: 10  # that is every 141750 updates
+  keep_last_epochs: 5  # keep half of all, as we train for 100 epochs
+
+task:
+  _name: audio_ccas
+  data: /local/datasets/Hyena_10s_energy_event_detected_pretrain_only_2024-09-03/manifests
+  unique_labels: "[]"
+  # Change feature extractor to account for reduced sample rate in meerkat data
+  # 24000Hz / 5 / 2 / 2 / 2 / 1 / 1 / 1 -> Effective encoder output frequency of 200Hz.
+  conv_feature_layers: '[(127, 63, 1)] +[(512, 10, 5)] + [(512, 3, 4)] + [(512, 3, 3)] + [(512, 3, 2)] + [(512, 3, 1)] + [(512, 2, 1)] * 2'
+  min_sample_size: 1
+  sample_rate: 24000
+  normalize: true
+  with_labels: false
+  min_label_size: 1  # Empty label files have Bytesize 1780, so to exclude them set this to 1780
+  verbose_tensorboard_logging: false
+  enable_padding: false
+
+dataset:
+  num_workers: 32
+  # max_tokens / sample_rate * distributed_world_size * update_freq is the batch size in seconds
+  # For training on asmodeus, we use ~1000s for training, as in the paper
+  max_tokens: 3000000  #  a token is a single audio frame, one epoch has 14175 steps (3927.5 hours)
+  skip_invalid_size_inputs_valid_test: true
+  validate_interval: 25
+  validate_interval_updates: 10000  # validate every m updates
+  required_batch_size_multiple: 1
+  disable_validation: true
+  train_subset: pretrain
+  valid_subset: valid_0
+
+distributed_training:
+  distributed_world_size: 4
+  ddp_backend: legacy_ddp
+
+criterion:
+  _name: expanded_model
+  segmentation_metrics: true
+  use_focal_loss: true  # this overrides label smoothing and uses the focal loss instead
+  log_keys:
+    - ema_decay
+    - target_var
+    - pred_var
+    - model_norm
+    - ema_norm
+    - masked_pct
+
+optimization:
+  update_freq: [ 2 ]
+  max_update: 1417431  # ~ 100 epochs
+  clip_norm: 1
+
+optimizer:
+  _name: composite
+  dynamic_groups: true
+  groups:
+    default:
+      lr_float: 0.00025
+      optimizer:
+        _name: adam
+        adam_betas: [ 0.9,0.98 ]
+        adam_eps: 1e-06
+        weight_decay: 0.01
+      lr_scheduler:
+        _name: cosine
+        warmup_updates: 10000
+
+lr_scheduler: pass_through
+
+model:
+  _name: data2vec_multi
+  loss_beta: 0
+  loss_scale: null
+
+  depth: 12
+  embed_dim: 768
+  clone_batch: 8
+
+  ema_decay: 0.9997
+  ema_end_decay: 1
+  ema_anneal_end_step: 300000
+  ema_encoder_only: false
+
+  average_top_k_layers: 12
+  instance_norm_target_layer: true
+  layer_norm_target_layer: false
+  layer_norm_targets: false
+
+  layerdrop: 0
+  norm_eps: 1e-5
+
+  supported_modality: AUDIO
+  target_mixup: false
+  source_mixup: 0.5  # The strength of the mixing (Uniformly sampled between this and 1.)
+  mixup_prob: 1.0  # How much of the source and targets should be mixed up (1.0 == 100%)
+  same_mixup: true  # Should we use the same strength for the full batch or use a random strength for every sample
+  mixing_window_length: 0.05  # The window length for the to-be-mixed windows in BC learning
+  gain_mode: "A_weighting"  # The mode with which the mixing gain is calculated, see BC learning paper
+
+  modalities:
+    audio:
+      sinc_input: true
+      apply_window_to_root: false
+      use_pswish: true
+      sinc_norm: "layer_norm"
+      conv_pos_depth: 5
+      conv_pos_width: 95
+      conv_pos_groups: 16
+      prenet_depth: 0  # The depth of the transformer based context_encoder
+      # mask_prob: 0.5
+      # mask_length: 5
+      mask_prob: 1.5  # Probability for a token being masked (Default is 0.65)
+      # The masking length if a token was chosen.
+      # This mask_prob and mask_length will mask ~93% of the input with a median masking length of 70 ms
+      mask_length: 2
+      mask_prob_adjust: 0.05
+      inverse_mask: false
+      mask_noise_std: 0.01
+      mask_dropout: 0
+      add_masks: false
+      ema_local_encoder: false
+      use_alibi_encoder: true
+      prenet_layerdrop: 0.05
+      prenet_dropout: 0.1
+      learned_alibi_scale: true
+      learned_alibi_scale_per_head: true
+      decoder:
+        input_dropout: 0.1
+        decoder_dim: 384
+        decoder_groups: 16
+        decoder_kernel: 7
+        decoder_layers: 4

--- a/configs/hyenas/finetune_mixup_100.yaml
+++ b/configs/hyenas/finetune_mixup_100.yaml
@@ -1,0 +1,109 @@
+# @package _group_
+hydra:
+  run:
+    dir: outputs/${now:%Y-%m-%d_%H-%M-%S}_hyena_ft_full-0_825-4
+
+common:
+  fp16: true
+  log_format: json
+  log_interval: 361  # this is in steps, not epochs ... log every epoch
+  tensorboard_logdir: tb
+  all_gather_list_size: 6500000
+
+checkpoint:
+  save_interval: 10  # that is every 3612 updates
+  keep_last_epochs: 10  # keep roughly all seven finetuning and the last three freeze update checkpoints
+  best_checkpoint_metric: metrics/finetune/f1
+
+task:
+  _name: audio_ccas
+  data: /home/jupyter-jzimmermann/ml/datasets/Hyena_10s_2025-10-28/manifests
+  max_sample_size: 320000
+  min_sample_size: 1000
+  min_label_size: 2936  # Empty label files have Bytesize 2936, so to exclude them set this to 2936
+  normalize: true
+  unique_labels: "['groan', 'oth', 'whoop', 'alarm_rumble', 'squitter', 'squeal', 'feeding', 'giggle', 'growl', 'focal']"
+  with_labels: true
+  conv_feature_layers: '[(127, 63, 1)] +[(512, 10, 5)] + [(512, 3, 4)] + [(512, 3, 3)] + [(512, 3, 2)] + [(512, 3, 1)] + [(512, 2, 1)] * 2'
+  sample_rate: 24000
+  verbose_tensorboard_logging: true
+
+dataset:
+  num_workers: 20
+  # original value: max_tokens: ~1300 seconds
+  # max_tokens / sample_rate * distributed_world_size * update_freq is the batch size in seconds
+  max_tokens: 285_000
+  skip_invalid_size_inputs_valid_test: true
+  validate_interval: 5000  # validate every N epochs, setting to 1000 or above effectively deactivates that
+  validate_interval_updates: 5000  # validate every m updates after validate_after_updates,
+  # so setting this to 2000 validates every 2000 updates after  validate_after_updates.
+  validate_after_updates: 10000  # dont validate until reaching this many updates, but then do a
+  # validate regardless of validate_interval_updates
+  train_subset: train_0  # we have 577840s in train_0 and a batch size of 1600s
+  valid_subset: valid_0
+
+distributed_training:
+  distributed_world_size: 4  # num of gpus -> we have 4
+  ddp_backend: legacy_ddp
+
+criterion:
+  _name: finetunecriterion
+  label_smoothing: 0.09  # 1 / num_classes as a rule of thumb
+  report_accuracy: true
+  segmentation_metrics: true
+  use_focal_loss: true  # this overrides label smoothing and uses the focal loss instead
+  metric_threshold: .175  # The minimum likelihood which is deemed a prediction
+  method: "avg"  # Parameters for the segmentation detection
+  sigma_s: 0.1
+  maxfilt_s: 0.1
+  max_duration_s: 0.5
+  lowP: 0.125
+
+optimization:
+  update_freq: [ 11 ]
+  max_update: 30000  # after the 10000 freeze updates we do 20000 normal finetuning steps -> 69.2 epochs
+  lr: [ 0.0001 ]
+
+optimizer:
+  _name: adam
+  adam_betas: (0.9,0.98)
+  adam_eps: 1e-08
+
+lr_scheduler:
+  _name: cosine  # replaced the tri stage scheduler with a cosine one
+  warmup_updates: 2000
+  warmup_init_lr: 1e-10
+  min_lr: 5e-06
+
+model:
+  _name: wav2vec_ccas_finetune
+  w2v_path: ???
+  # For the first 10k updates only the output classifier is trained,
+  # after which the Transformer is also updated.
+  # The feature encoder is not trained during fine-tuning.
+  freeze_finetune_updates: 10000
+  feature_grad_mult: 0.0
+  apply_mask: true
+  average_top_k_layers: 12 # Layers in the middle perform best, see arXiv:2105.11084 [cs.CL]
+  # Regularization terms
+  mask_prob: 0.825  # Probability - the R term in the paper - for a token being masked (Default is 0.65)
+  # The masking length if a token was chosen.
+  mask_length: 4
+  # to get the prob from the paper you have to:
+  # mask_channel_prob * num_channels (1024) / mask_channel_length / batch_size
+  mask_channel_prob: 0
+  mask_channel_length: 64
+  dropout: 0.1
+  dropout_input: 0.0
+  activation_dropout: 0.1
+  attention_dropout: 0.2
+  final_dropout: 0.0
+  layerdrop: 0.1
+  drop_path: 0.0
+  target_mixup: true  # Should we mixup the targets as well
+  source_mixup: 0.5  # The strength of the mixing (Uniformly sampled between this and 1.)
+  mixup_prob: 1.0  # How much of the source and targets should be mixed up (1.0 == 100%)
+  same_mixup: true  # Should we use the same strength for the full batch or use a random strength for every sample
+  mixing_window_length: 0.05  # The window length for the to-be-mixed windows in BC learning
+  gain_mode: "A_weighting"  # The mode with which the mixing gain is calculated, see BC learning paper
+  load_pretrain_weights: false  # should we attempt to load the linear eval projection layer weights from pretrain

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pyarrow==15.0.2
 scikit_learn==1.2.0
 scipy==1.10.0
 seaborn==0.13.2
-scikit-image==0.23.1
+scikit-image==0.22.0
 soundfile==0.12.1
 tensorflow==2.11.0
 timm==0.6.12

--- a/scripts/animal2vec_manifest.py
+++ b/scripts/animal2vec_manifest.py
@@ -88,17 +88,11 @@ def get_parser():
         "Will be ignored when leave-p-out is set.",
     )
     parser.add_argument(
-        "--exclude-from-finetune-individuals",
-        type=str,
-        default="",
-        nargs="+",
-        help="Individuals to exclude from the fine-tuning phase entirely",
-    )
-    parser.add_argument(
         "--id-lookup-file-path",
         type=str,
         default="",
-        help="File path that maps randomised file names to their non-randomised individual IDs. Will be used only when valid-set-individuals is set.",
+        help="File path that maps randomised file names to their non-randomised name which include individual information."
+        "Will be used only when valid-set-individuals is set.",
     )
 
     return parser
@@ -135,29 +129,6 @@ def get_files(dir, re_obj=None):
 def flatten(l):
     """helper function for flattening a list of lists"""
     return [item for sublist in l for item in sublist]
-
-
-def remove_excluded_individuals(
-    labels_X: List[str],
-    targets: List[str],
-    exclude_individuals: List[str],
-    id_lookup_file_path: Path = "",
-) -> Tuple[List[str], List[int]]:
-    """
-    Removes all files that belong to excluded individuals
-    """
-    exclude_indices = []
-    for individual in exclude_individuals:
-        idx_ind_exclude = get_files_indices_one_individual(
-            individual, labels_X, id_lookup_file_path
-        )
-        exclude_indices.extend(idx_ind_exclude)
-
-    include_indices = list(set(range(len(labels_X))) - set(exclude_indices))
-    included_labels_X = [labels_X[i] for i in include_indices]
-    included_targets = [targets[i] for i in include_indices]
-
-    return included_labels_X, included_targets
 
 
 def get_files_indices_one_individual(
@@ -353,17 +324,6 @@ def main(args):
             continue
         line = "{}\t{}".format(os.path.relpath(file_path, dir_path), frames)
         print(line, file=pretrain_f)
-
-    if args.exclude_from_finetune_individuals:
-        print(
-            f"Excluding individuals {args.exclude_from_finetune_individuals} from the fine-tuning phase entirely."
-        )
-        labels_X, targets = remove_excluded_individuals(
-            labels_X,
-            targets,
-            args.exclude_from_finetune_individuals,
-            args.id_lookup_file_path,
-        )
 
     if not args.valid_set_individuals:
         sss = MultilabelStratifiedShuffleSplit(

--- a/scripts/animal2vec_manifest.py
+++ b/scripts/animal2vec_manifest.py
@@ -167,27 +167,26 @@ def get_files_indices_one_individual(
     Gets the indices of all files that belong to one individual
     """
     if not id_lookup_file_path:
-        indices = [
+        indices_indiv = [
             i
             for i in range(len(labels_X))
             if individual.lower() in Path(labels_X[i]).stem.lower()
         ]
         print(
-            f"Found {len(indices)} files for individual {individual} based on file name matching."
+            f"Found {len(indices_indiv)} files for individual {individual} based on file name matching."
         )
     else:
-        lookup_file_df = pd.DataFrame(pd.read_csv(id_lookup_file_path))
-        # TODO: return the list of indexes based on the lookup file
-        decoded_file_names_df = lookup_file_df[
-            lookup_file_df["individual_id"] == individual
-        ]["file_name"]
-        encoded_file_names = decoded_file_names_df["encoded_file_name"].tolist()
-        indices = [
-            i
-            for i in range(len(labels_X))
-            if any(encoded_name in labels_X[i] for encoded_name in encoded_file_names)
-        ]
-    return indices
+        lookup_file_df = pd.DataFrame(pd.read_csv(id_lookup_file_path, sep="\t"))
+        lookup_file_df_one_indiv = lookup_file_df[lookup_file_df['OriginalName'].str.contains(f"_{individual}")]
+        randomised_file_names = lookup_file_df_one_indiv['RandomizedName'].tolist()
+        indices_indiv = []
+        for file_name in randomised_file_names:
+            idx_file_name = [i for i in range(len(labels_X)) if file_name in labels_X[i]]
+            assert len(idx_file_name) <= 1
+            if idx_file_name:
+                indices_indiv.append(idx_file_name[0])
+
+    return indices_indiv
 
 
 def split_train_valid_by_individuals(

--- a/scripts/get_AP_scores_from_predictions.py
+++ b/scripts/get_AP_scores_from_predictions.py
@@ -1,0 +1,161 @@
+import argparse
+import ast
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import h5py
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+from sklearn.metrics import average_precision_score
+from tqdm import tqdm
+
+
+def get_lbl_path_from_wav_path(wav_path: Path) -> Path:
+    lbl_path = str(wav_path.with_suffix(".h5"))
+    lbl_path = Path(lbl_path.replace("/wav/", "/lbl/"))
+    return lbl_path
+
+
+def remove_empty_rows(
+    predictions: NDArray, targets: NDArray
+) -> Tuple[NDArray, NDArray]:
+    """
+    When saving the predictions, the predictions and targets are interpolated with a lot of empty predictions,
+    which makes the predictions and the targets unnecessarily big. Remove rows where all target values are zero.
+    This assumes that the targets have at least one positive class for each audio clip (eg row).
+    """
+    non_empty_indices = np.where(targets.sum(axis=1) != 0)[0]
+    return predictions[non_empty_indices], targets[non_empty_indices]
+
+
+def get_predictions(
+    predictions_path: str, segmented: bool = True
+) -> Tuple[NDArray, NDArray]:
+    predictions = []
+    targets = []
+
+    with h5py.File(predictions_path, "r") as h5_file:
+        for event in tqdm(h5_file):
+            if segmented:
+                predictions.append(h5_file[event]["segmented_likelihood"])
+                targets.append(h5_file[event]["segmented_target"])
+            else:
+                predictions.append(h5_file[event]["likelihood"])
+                targets.append(h5_file[event]["target"])
+        predictions = np.array(predictions)
+        predictions = predictions.reshape(-1, predictions.shape[-1])
+        targets = np.array(targets)
+        targets = targets.reshape(
+            -1, targets.shape[-1]
+        )  # shape (num_segments, num_classes)
+    predictions, targets = remove_empty_rows(predictions, targets)
+    return predictions, targets
+
+
+def get_tot_duration_vocalizations(targets: NDArray, sample_rate: int) -> List[float]:
+    """
+    Calculate the total duration of vocalizations in seconds.
+
+    Args:
+        targets (NDArray): Array of shape (num_segments, num_classes) containing target labels.
+        sample_rate (float): Sample rate of the audio in Hz. Default is 24000 Hz.
+
+    Returns:
+        float: Total duration of vocalizations in seconds.
+    """
+    num_vocalization_frames = np.sum(targets, axis=0)
+    total_duration_min = num_vocalization_frames / (sample_rate * 60)
+    return np.round(total_duration_min, 1).tolist()
+
+
+def get_results_from_predictions(
+    predictions_file_path: str,
+    unique_labels: List[str],
+    sample_rate: int = 200,
+    output_file_path: Optional[str] = None,
+):
+    """
+    Reads predictions from a file and processes them to generate results.
+
+    Args:
+        predictions_file_path (str): h5 path to the file containing predictions. The predictions should be obtained by running the get_results_for_single_manifest.py script with the flag --export-predictions set to True.
+        output_file_path (Optional[str]): Path to save the processed results. If None, returns the results as a pandas DataFrame
+    Returns:
+        pd.DataFrame: Processed results
+    """
+    results_dict = {
+        "Voc. type": unique_labels,
+        "Number of voc.": [],
+        "Total duration voc. (min)": [],
+        "Average Precision": [],
+    }
+    predictions, targets = get_predictions(predictions_file_path)
+    _, targets_framewise = get_predictions(predictions_file_path, segmented=False)
+    results_dict["Total duration voc. (min)"] = get_tot_duration_vocalizations(
+        targets_framewise, sample_rate
+    )
+
+    # AP for each class
+    for i in range(len(unique_labels)):
+        print(unique_labels[i])
+        num_elements_vox_type = np.sum(targets[:, i]).astype(int)
+        results_dict["Number of voc."].append(num_elements_vox_type)
+        predictions_one_class = predictions[:, i]
+        targets_one_class = targets[:, i].astype(int)
+        results_dict["Average Precision"].append(
+            average_precision_score(targets_one_class, predictions_one_class)
+        )
+
+    # averaged mAP for all the classes
+    results_dict["Voc. type"].append("all")
+    results_dict["Average Precision"].append(
+        average_precision_score(
+            targets.flatten().astype(int), predictions.flatten(), average="micro"
+        )
+    )
+    results_dict["Number of voc."].append(np.sum(targets))
+
+    tot_duration = np.array(results_dict["Total duration voc. (min)"]).sum()
+    if "focal" in unique_labels:
+        tot_duration -= results_dict["Total duration voc. (min)"][
+            unique_labels.index("focal")
+        ]
+    results_dict["Total duration voc. (min)"].append(tot_duration)
+
+    results_df = pd.DataFrame(results_dict)
+    results_df.sort_values(by="Average Precision", ascending=False, inplace=True)
+    results_df = results_df.round(3)
+    if output_file_path is not None:
+        results_df.to_csv(output_file_path, index=False)
+
+    return results_df
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--predictions-file-path",
+        type=str,
+        required=True,
+        help="Path to the predictions h5 file. The latter can be obtained by running the get_results_for_single_manifest.py script with the flag --export-predictions set to True.",
+    )
+    parser.add_argument(
+        "--unique-labels",
+        type=str,
+        help="A string list that, when evaluated, holds the names for the used classes.",
+    )
+    parser.add_argument(
+        "--output-file-path",
+        type=str,
+        default=None,
+        help="Path to save the results csv file. If not provided, the results will not be saved to a file.",
+    )
+    prediction_file_path = "/home/jupyter-cangonin/eas_shared/meerkat/working/animal2vec/Coati_2025-03-17_10s_randomized/predictions_Wav2VecCcasFinetune_2025-10-28_16-01-09_hyena_ft_full-0_825-4.pt_0_16_valid_0_animal2vec.h5"
+    args = parser.parse_args()
+    print(args)
+    get_results_from_predictions(
+        predictions_file_path=prediction_file_path,
+        unique_labels=ast.literal_eval(args.unique_labels),
+        output_file_path="/home/jupyter-cangonin/github/self-supervised-animal-vocalizations/data/results_new_hyena_model.csv",
+    )

--- a/scripts/prepare_arb_data_for_audio_pretraining.py
+++ b/scripts/prepare_arb_data_for_audio_pretraining.py
@@ -320,7 +320,7 @@ def main(args):
                     total=len(files)):
         
                 total_duration += sum(total_dur)
-                tot_num_files += c_
+                tot_num_files += sum(c_)
                 random_names_dicts.append(rand_dict)
                 pbar.update(1)
     random_names_dictionary = {k: v for d in random_names_dicts for k, v in d.items()}

--- a/scripts/prepare_arb_data_for_audio_pretraining.py
+++ b/scripts/prepare_arb_data_for_audio_pretraining.py
@@ -97,7 +97,8 @@ def get_parser():
     )
     parser.add_argument("--num-subfolders", type=int, required=False, help="Number of subfolders to create in output folder."
                         "This is useful when dealing with a large number of files to avoid having too many files in a single folder."
-                        "If not provided, we will use the default file structure for non anonymised data and one single folder for anonymised data."
+                        "Only active when --randomize-file-names is True. If not provided, all the files will be put into one single folder."
+                        ""
     )
     parser.add_argument(
         "--seed", default=1612, type=int, metavar="N", help="random seed"
@@ -181,8 +182,8 @@ def iteration(file, args, id_generator, labels, channel_dict):
             out_folders_list = [str(i) for i in range(args.num_subfolders)] if args.num_subfolders else [""]
             base_out_filename = random.choice(out_folders_list)
             _new_rand_name = id_generator()
-            if _new_rand_name in random_names_dictionary:
-                while _new_rand_name in random_names_dictionary:  # Create a new name until it is unique
+            if os.path.join(base_out_filename, _new_rand_name) in random_names_dictionary:
+                while os.path.join(base_out_filename, _new_rand_name) in random_names_dictionary:  # Create a new name until it is unique
                     _new_rand_name = id_generator()
             random_names_dictionary.update({os.path.join(base_out_filename, _new_rand_name): f_name_base})
             f_name_base = _new_rand_name

--- a/scripts/prepare_arb_data_for_audio_pretraining.py
+++ b/scripts/prepare_arb_data_for_audio_pretraining.py
@@ -96,8 +96,12 @@ def get_parser():
                        "zeroth channel will be used per default"
     )
     parser.add_argument("--num-subfolders", type=int, required=False, help="Number of subfolders to create in output folder."
-                        "This is useful when dealing with a large number of files to avoid ""too many files in a single folder. "
-                        "If not provided, will use the default file structure for non anonymised data and one single folder for anonymised data.")
+                        "This is useful when dealing with a large number of files to avoid having too many files in a single folder."
+                        "If not provided, we will use the default file structure for non anonymised data and one single folder for anonymised data."
+    )
+    parser.add_argument(
+        "--seed", default=1612, type=int, metavar="N", help="random seed"
+    )                   
     return parser
 
 
@@ -347,7 +351,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    random.seed(10)
     parser = get_parser()
     args = parser.parse_args()
+    random.seed(args.seed)
     main(args)


### PR DESCRIPTION
This PR:
- adds the configuration files used to pretrain and finetune animal2vec hyena model in the `configs/hyena folder`
- adds a file to generate average precision scores from the .h5 predictions file
- Fixes two bugs in the `scripts/prepare_arb_data_for_audio_pretraining.py`
    - using a list of `futures` with all the audio files will submit all the tasks at once retain them for all the files until the end of the execution of the script, causing the memory to grow progressively and trigger an OOM error eventually. Instead, I streamed the tasks using the `map()` method of the `ThreadPoolExecutor`.
    - When the script is run with the `--randomize-file-names` flag on, all the audio files are put in the same folder, which will cause errors when this number becomes too high. Therefore, I added a `--num-subfolders` to separate the audio files into these subfolders. Right now, this option is only active when the `--randomize-file-names`  flag is on
- Adds the option of selecting some individuals only for the validation set in the file  `scripts/animal2vec_manifest.py`