### PR TITLE
Fix error in AP calculation and update classes hyena config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,8 +127,7 @@ data-bin/
 scripts/libPeak/_peak_detection.cpp
 
 # VSCODE
-.vscode/ftp-sync.json
-.vscode/settings.json
+.vscode/
 
 # Experimental Folder
 experimental/*
@@ -144,3 +143,4 @@ outputs
 # Other
 results
 logs
+data/

--- a/configs/hyenas/finetune_mixup_100.yaml
+++ b/configs/hyenas/finetune_mixup_100.yaml
@@ -22,7 +22,7 @@ task:
   min_sample_size: 1000
   min_label_size: 2936  # Empty label files have Bytesize 2936, so to exclude them set this to 2936
   normalize: true
-  unique_labels: "['groan', 'oth', 'whoop', 'alarm_rumble', 'squitter', 'squeal', 'feeding', 'giggle', 'growl', 'focal']"
+  unique_labels: "['groan', 'oth', 'whoop', 'alarm_rumble', 'squitter', 'squeal', 'feeding', 'giggle', 'growl', 'snore', 'focal']"
   with_labels: true
   conv_feature_layers: '[(127, 63, 1)] +[(512, 10, 5)] + [(512, 3, 4)] + [(512, 3, 3)] + [(512, 3, 2)] + [(512, 3, 1)] + [(512, 2, 1)] * 2'
   sample_rate: 24000

--- a/scripts/get_ap_scores_from_predictions.py
+++ b/scripts/get_ap_scores_from_predictions.py
@@ -33,7 +33,11 @@ def remove_empty_rows(
         Tuple[NDArray, NDArray]: Filtered predictions and targets with empty rows removed.
 
     """
-    non_empty_indices = np.where(targets.sum(axis=1) != 0)[0]
+    empty_indices_targets = np.where(targets.sum(axis=1) == 0)[0]
+    empty_indices_pred = np.where(predictions.sum(axis=1) == 0)[0]
+    empty_indices = np.intersect1d(empty_indices_pred, empty_indices_targets)
+    all_indices = np.arange(len(targets))
+    non_empty_indices = np.setdiff1d(all_indices, empty_indices)
     return predictions[non_empty_indices], targets[non_empty_indices]
 
 


### PR DESCRIPTION
The error was an incorrect way to determine which parts of the predictions and targets arrays were the interpolation 